### PR TITLE
Make per-task bar a binary toggle and gate Serve!

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,7 @@ jobs:
           path: dist
   deploy:
     needs: build
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/src/screens/ListDetail.tsx
+++ b/src/screens/ListDetail.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import Avatar from "../components/Avatar";
-import { actions, taskBalance, useStore } from "../store";
+import { actions, useStore } from "../store";
 import type { Task } from "../types";
 
 type Props = {
@@ -9,19 +9,13 @@ type Props = {
   onEdit: () => void;
 };
 
+const isMyTurn = (t: Task) => t.lastServedBy !== "me";
+
 export default function ListDetail({ listId, onBack, onEdit }: Props) {
   const { lists, account } = useStore();
   const list = lists.find((l) => l.id === listId);
   const myName = account?.name ?? "You";
   const [toast, setToast] = useState<string | null>(null);
-  const [serveIndex, setServeIndex] = useState(0);
-
-  const serveCandidates = useMemo<Task[]>(() => {
-    if (!list) return [];
-    // Tasks that mate served last (or never), so it's "your" turn
-    const yourTurn = list.tasks.filter((t) => t.lastServedBy !== "me");
-    return yourTurn.length > 0 ? yourTurn : list.tasks;
-  }, [list]);
 
   useEffect(() => {
     if (!toast) return;
@@ -48,7 +42,14 @@ export default function ListDetail({ listId, onBack, onEdit }: Props) {
     );
   }
 
-  const serveTask = serveCandidates[serveIndex % Math.max(serveCandidates.length, 1)];
+  const nextForMe = list.tasks.find(isMyTurn);
+
+  const flip = (t: Task) => {
+    const mine = isMyTurn(t);
+    const by = mine ? "me" : "mate";
+    actions.serve(list.id, t.id, by);
+    setToast(mine ? `Served — ${t.name}` : `${list.mateName} served back`);
+  };
 
   return (
     <div className="screen">
@@ -80,36 +81,36 @@ export default function ListDetail({ listId, onBack, onEdit }: Props) {
           </p>
         ) : (
           list.tasks.map((t) => {
-            const pos = taskBalance(t) * 100;
-            const greenSide = t.lastServedBy === "me"; // recently your turn => mate's lead, shown green-ish
+            const mine = isMyTurn(t);
             return (
               <div className="task" key={t.id}>
                 <div className="label">{t.name}</div>
-                <div
-                  className={`bar ${greenSide ? "green" : ""}`}
-                  style={{ ["--pos" as string]: `${pos}%` }}
-                  aria-label={`${t.name} balance`}
+                <button
+                  type="button"
+                  className={`toggle ${mine ? "mine" : "mate"}`}
+                  onClick={() => flip(t)}
+                  aria-pressed={!mine}
+                  aria-label={`${t.name} — ${mine ? "your serve" : `${list.mateName}'s serve`}`}
                 >
-                  <div className="fill-left" />
-                  <div className="knob" />
-                </div>
+                  <span className="toggle-fill" />
+                  <span className="toggle-knob" />
+                </button>
               </div>
             );
           })
         )}
 
-        {serveTask && (
+        {list.tasks.length > 0 && (
           <div className="task serve">
-            <div className="label">{serveTask.name}</div>
+            <div className="label">
+              {nextForMe ? nextForMe.name : `Waiting for ${list.mateName}…`}
+            </div>
             <button
               className="btn"
-              onClick={() => {
-                actions.serve(list.id, serveTask.id, "me");
-                setToast(`Served! ${serveTask.name}`);
-                setServeIndex((i) => i + 1);
-              }}
+              disabled={!nextForMe}
+              onClick={() => nextForMe && flip(nextForMe)}
             >
-              Serve!
+              {nextForMe ? "Serve!" : "Waiting for serve"}
             </button>
           </div>
         )}

--- a/src/store.ts
+++ b/src/store.ts
@@ -193,23 +193,3 @@ function updateList(
   };
 }
 
-// Compute a 0..1 position representing the player's relative load. 0.5 = balanced.
-// We blend per-task meCount/mateCount with a recency bias from lastServedBy.
-export function taskBalance(t: Task): number {
-  const total = t.meCount + t.mateCount;
-  if (total === 0) {
-    if (t.lastServedBy === "me") return 0.7;
-    if (t.lastServedBy === "mate") return 0.3;
-    return 0.5;
-  }
-  // Position closer to 1 means "me" has done more recently/more often.
-  const ratio = t.meCount / total; // 0..1
-  // Slight nudge toward whoever served last to reflect recency.
-  const recency = t.lastServedBy === "me" ? 0.05 : t.lastServedBy === "mate" ? -0.05 : 0;
-  const pos = clamp01(ratio + recency);
-  return pos;
-}
-
-function clamp01(v: number): number {
-  return Math.max(0.05, Math.min(0.95, v));
-}

--- a/src/styles.css
+++ b/src/styles.css
@@ -168,6 +168,13 @@ a {
 .btn:hover {
   filter: brightness(1.05);
 }
+.btn:disabled {
+  background: var(--track);
+  color: var(--text-dim);
+  cursor: not-allowed;
+  filter: none;
+  transform: none;
+}
 .btn-ghost {
   background: transparent;
   border: 1px solid var(--danger);
@@ -358,36 +365,53 @@ a {
   font-size: 14px;
   color: var(--text);
 }
-.bar {
-  --pos: 50%;
-  height: 14px;
-  border-radius: 999px;
-  background: var(--purple);
+.toggle {
   position: relative;
+  width: 100%;
+  height: 28px;
+  border-radius: 999px;
+  background: var(--track);
   overflow: hidden;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  display: block;
 }
-.bar.green {
+.toggle:focus-visible {
+  outline: 2px solid var(--purple);
+  outline-offset: 2px;
+}
+.toggle .toggle-fill {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 50%;
+  background: var(--purple);
+  transition: transform 260ms cubic-bezier(0.4, 0, 0.2, 1),
+    background-color 220ms ease;
+}
+.toggle.mate .toggle-fill {
+  transform: translateX(100%);
   background: var(--green-deep);
 }
-.bar .knob {
+.toggle .toggle-knob {
   position: absolute;
   top: 50%;
-  transform: translate(-50%, -50%);
-  left: var(--pos);
-  width: 18px;
-  height: 18px;
+  width: 22px;
+  height: 22px;
   border-radius: 50%;
   background: #fff;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+  transform: translate(-50%, -50%);
+  left: 25%;
+  transition: left 260ms cubic-bezier(0.4, 0, 0.2, 1);
 }
-.bar .fill-left {
-  position: absolute;
-  inset: 0 auto 0 0;
-  width: var(--pos);
-  background: #fff;
+.toggle.mate .toggle-knob {
+  left: 75%;
 }
-.bar.green .fill-left {
-  background: #fff;
+.toggle:active {
+  filter: brightness(1.05);
 }
 
 /* Edit list */


### PR DESCRIPTION
- Replaces the gradient-style balance bar with a two-state toggle: knob on the left (purple) when the ball is on your side, knob on the right (green) when waiting on your mate. Tapping flips the toggle and records the serve from the side that has the ball.
- Disables the Serve! CTA when no task is on your side, so you can't rapid-fire serves before your mate plays back. Label switches to "Waiting for serve" with the mate's pending task name.
- Drops the unused taskBalance helper.
- Restricts the Pages deploy job to master/main so feature-branch pushes don't show a red deploy step (build still runs as a check).

https://claude.ai/code/session_016MpnftzBfyNmfW864UVSBa