### PR TITLE
Smash animation, edge knob, English copy

### DIFF
--- a/src/screens/ListDetail.tsx
+++ b/src/screens/ListDetail.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import Avatar from "../components/Avatar";
 import { actions, useStore } from "../store";
-import type { Task } from "../types";
+import type { PlayerKey, Task } from "../types";
 
 type Props = {
   listId: string;
@@ -16,12 +16,26 @@ export default function ListDetail({ listId, onBack, onEdit }: Props) {
   const list = lists.find((l) => l.id === listId);
   const myName = account?.name ?? "You";
   const [toast, setToast] = useState<string | null>(null);
+  const [smashId, setSmashId] = useState<string | null>(null);
+  const [scoreFlash, setScoreFlash] = useState<PlayerKey | null>(null);
 
   useEffect(() => {
     if (!toast) return;
     const id = setTimeout(() => setToast(null), 1500);
     return () => clearTimeout(id);
   }, [toast]);
+
+  useEffect(() => {
+    if (!smashId) return;
+    const id = setTimeout(() => setSmashId(null), 700);
+    return () => clearTimeout(id);
+  }, [smashId]);
+
+  useEffect(() => {
+    if (!scoreFlash) return;
+    const id = setTimeout(() => setScoreFlash(null), 600);
+    return () => clearTimeout(id);
+  }, [scoreFlash]);
 
   if (!list) {
     return (
@@ -46,9 +60,11 @@ export default function ListDetail({ listId, onBack, onEdit }: Props) {
 
   const flip = (t: Task) => {
     const mine = isMyTurn(t);
-    const by = mine ? "me" : "mate";
+    const by: PlayerKey = mine ? "me" : "mate";
     actions.serve(list.id, t.id, by);
-    setToast(mine ? `Served — ${t.name}` : `${list.mateName} served back`);
+    setSmashId(t.id);
+    setScoreFlash(by);
+    setToast(mine ? `Smashed — ${t.name}` : `${list.mateName} smashed back`);
   };
 
   return (
@@ -69,7 +85,7 @@ export default function ListDetail({ listId, onBack, onEdit }: Props) {
       <div className="screen-body">
         <div className="players">
           <Avatar name={myName} variant="me" size="lg" />
-          <div className="score">
+          <div className={`score ${scoreFlash ? `flash ${scoreFlash}` : ""}`}>
             {list.meScore} - {list.mateScore}
           </div>
           <Avatar name={list.mateName} variant="mate" size="lg" />
@@ -82,18 +98,20 @@ export default function ListDetail({ listId, onBack, onEdit }: Props) {
         ) : (
           list.tasks.map((t) => {
             const mine = isMyTurn(t);
+            const smashing = smashId === t.id;
             return (
               <div className="task" key={t.id}>
                 <div className="label">{t.name}</div>
                 <button
                   type="button"
-                  className={`toggle ${mine ? "mine" : "mate"}`}
+                  className={`toggle ${mine ? "mine" : "mate"} ${smashing ? "smashing" : ""}`}
                   onClick={() => flip(t)}
                   aria-pressed={!mine}
-                  aria-label={`${t.name} — ${mine ? "your serve" : `${list.mateName}'s serve`}`}
+                  aria-label={`${t.name} — ${mine ? "your smash" : `${list.mateName}'s smash`}`}
                 >
-                  <span className="toggle-fill" />
                   <span className="toggle-knob" />
+                  <span className="toggle-trail" aria-hidden />
+                  {smashing && <span className="smash-text">SMASH!</span>}
                 </button>
               </div>
             );
@@ -110,7 +128,7 @@ export default function ListDetail({ listId, onBack, onEdit }: Props) {
               disabled={!nextForMe}
               onClick={() => nextForMe && flip(nextForMe)}
             >
-              {nextForMe ? "Serve!" : "Waiting for serve"}
+              {nextForMe ? "Smash!" : "Waiting for smash"}
             </button>
           </div>
         )}

--- a/src/store.ts
+++ b/src/store.ts
@@ -18,11 +18,11 @@ const seededDemo = (name: string): AppState => ({
       meScore: 1,
       mateScore: 3,
       tasks: [
-        { id: id(), name: "Tvätta", lastServedBy: "mate", meCount: 0, mateCount: 2 },
-        { id: id(), name: "Gå ut med soporna", lastServedBy: "mate", meCount: 1, mateCount: 1 },
-        { id: id(), name: "Dammsuga", lastServedBy: "me", meCount: 1, mateCount: 0 },
-        { id: id(), name: "Mata katten", lastServedBy: null, meCount: 0, mateCount: 0 },
-        { id: id(), name: "Mata grannens jobbiga katt", lastServedBy: null, meCount: 0, mateCount: 0 },
+        { id: id(), name: "Do laundry", lastServedBy: "mate", meCount: 0, mateCount: 2 },
+        { id: id(), name: "Take out the trash", lastServedBy: "mate", meCount: 1, mateCount: 1 },
+        { id: id(), name: "Vacuum", lastServedBy: "me", meCount: 1, mateCount: 0 },
+        { id: id(), name: "Feed the cat", lastServedBy: null, meCount: 0, mateCount: 0 },
+        { id: id(), name: "Feed the neighbour's annoying cat", lastServedBy: null, meCount: 0, mateCount: 0 },
       ],
     },
     {

--- a/src/styles.css
+++ b/src/styles.css
@@ -368,50 +368,173 @@ a {
 .toggle {
   position: relative;
   width: 100%;
-  height: 28px;
+  height: 30px;
   border-radius: 999px;
-  background: var(--track);
+  background: var(--purple);
   overflow: hidden;
   border: none;
   padding: 0;
   cursor: pointer;
   display: block;
+  transition: background-color 320ms ease;
+}
+.toggle.mate {
+  background: var(--green-deep);
 }
 .toggle:focus-visible {
   outline: 2px solid var(--purple);
   outline-offset: 2px;
 }
-.toggle .toggle-fill {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  width: 50%;
-  background: var(--purple);
-  transition: transform 260ms cubic-bezier(0.4, 0, 0.2, 1),
-    background-color 220ms ease;
-}
-.toggle.mate .toggle-fill {
-  transform: translateX(100%);
-  background: var(--green-deep);
-}
 .toggle .toggle-knob {
   position: absolute;
   top: 50%;
-  width: 22px;
-  height: 22px;
+  width: 24px;
+  height: 24px;
   border-radius: 50%;
   background: #fff;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
-  transform: translate(-50%, -50%);
-  left: 25%;
-  transition: left 260ms cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.45);
+  transform: translateY(-50%);
+  left: 3px;
+  transition:
+    left 360ms cubic-bezier(0.34, 1.6, 0.4, 1),
+    box-shadow 220ms ease,
+    width 220ms cubic-bezier(0.34, 1.6, 0.4, 1);
+  z-index: 2;
 }
 .toggle.mate .toggle-knob {
-  left: 75%;
+  left: calc(100% - 27px);
 }
 .toggle:active {
   filter: brightness(1.05);
+}
+
+/* Trail behind the knob during smash */
+.toggle .toggle-trail {
+  position: absolute;
+  top: 50%;
+  height: 4px;
+  width: 0;
+  transform: translateY(-50%);
+  background: linear-gradient(
+    to right,
+    rgba(255, 255, 255, 0) 0%,
+    rgba(255, 255, 255, 0.85) 100%
+  );
+  border-radius: 999px;
+  pointer-events: none;
+  opacity: 0;
+  z-index: 1;
+}
+.toggle.mine .toggle-trail {
+  right: 3px;
+  background: linear-gradient(
+    to left,
+    rgba(255, 255, 255, 0) 0%,
+    rgba(255, 255, 255, 0.85) 100%
+  );
+}
+.toggle.mate .toggle-trail {
+  left: 3px;
+}
+.toggle.smashing .toggle-trail {
+  animation: trail-fade 360ms ease-out;
+}
+@keyframes trail-fade {
+  0% {
+    width: 0;
+    opacity: 0;
+  }
+  35% {
+    width: calc(100% - 30px);
+    opacity: 1;
+  }
+  100% {
+    width: calc(100% - 30px);
+    opacity: 0;
+  }
+}
+
+/* The knob squashes during the smash, then settles */
+.toggle.smashing .toggle-knob {
+  box-shadow:
+    0 1px 4px rgba(0, 0, 0, 0.45),
+    0 0 18px rgba(255, 255, 255, 0.8);
+  animation: knob-squash 360ms cubic-bezier(0.34, 1.6, 0.4, 1);
+}
+@keyframes knob-squash {
+  0% {
+    width: 24px;
+  }
+  40% {
+    width: 38px;
+  }
+  100% {
+    width: 24px;
+  }
+}
+
+/* Brief brightness flash on the bar itself */
+.toggle.smashing {
+  animation: bar-flash 360ms ease;
+}
+@keyframes bar-flash {
+  0%,
+  100% {
+    filter: brightness(1) saturate(1);
+  }
+  35% {
+    filter: brightness(1.35) saturate(1.2);
+  }
+}
+
+/* SMASH! pop text */
+.smash-text {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  font-size: 12px;
+  color: #fff;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.5);
+  pointer-events: none;
+  animation: smash-pop 700ms ease-out forwards;
+  z-index: 3;
+  white-space: nowrap;
+}
+@keyframes smash-pop {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.6) rotate(-6deg);
+  }
+  20% {
+    opacity: 1;
+    transform: translate(-50%, -110%) scale(1.25) rotate(-3deg);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -200%) scale(1) rotate(0deg);
+  }
+}
+
+/* Score bump animation */
+.players .score.flash {
+  animation: score-bump 500ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.players .score.flash.mate {
+  color: var(--orange);
+}
+@keyframes score-bump {
+  0% {
+    transform: scale(1);
+  }
+  40% {
+    transform: scale(1.35);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 
 /* Edit list */


### PR DESCRIPTION
## Summary
- Toggle visual: full-width colour fill (purple = your turn, green = mate's turn) with the white knob sitting flush at the edge.
- Smash animation when you tap the toggle: knob squashes + glows, a white trail wipes across the bar, the bar flashes brighter, and a "SMASH!" label pops up out of the toggle. The score side that just earned a point bumps (orange for the mate).
- Copy: every "serve" → "smash" (button, disabled label, toast, aria-labels).
- Seeded list now uses English chore names instead of Swedish.

Note: existing localStorage data is preserved, so already-created lists keep their (Swedish) task names. Log out → sign up to see the new seeded list.

## Test plan
- [ ] Tap a toggle — knob slides edge-to-edge, smash animation fires
- [ ] Score bumps for the side that scored
- [ ] After smashing, the big CTA disables ("Waiting for smash") until the toggle is flipped back
- [ ] Fresh sign up shows English chore names

https://claude.ai/code/session_016MpnftzBfyNmfW864UVSBa

---
_Generated by [Claude Code](https://claude.ai/code/session_016MpnftzBfyNmfW864UVSBa)_