### PR TITLE
Full-width list cards on All Lists

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -282,6 +282,8 @@ a {
   text-align: center;
   cursor: pointer;
   transition: transform 100ms ease;
+  width: 100%;
+  color: var(--text);
 }
 .list-card:hover {
   transform: translateY(-1px);


### PR DESCRIPTION
Adds `width: 100%` to `.list-card` so cards span the full screen-body width on the All Lists screen, instead of shrinking to their content.

https://claude.ai/code/session_016MpnftzBfyNmfW864UVSBa

---
_Generated by [Claude Code](https://claude.ai/code/session_016MpnftzBfyNmfW864UVSBa)_