### PR TITLE
iOS-style smash notification

### DIFF
--- a/src/screens/ListDetail.tsx
+++ b/src/screens/ListDetail.tsx
@@ -16,13 +16,19 @@ export default function ListDetail({ listId, onBack, onEdit }: Props) {
   const list = lists.find((l) => l.id === listId);
   const myName = account?.name ?? "You";
   const [toast, setToast] = useState<string | null>(null);
+  const [toastClosing, setToastClosing] = useState(false);
   const [smashId, setSmashId] = useState<string | null>(null);
   const [scoreFlash, setScoreFlash] = useState<PlayerKey | null>(null);
 
   useEffect(() => {
     if (!toast) return;
-    const id = setTimeout(() => setToast(null), 1500);
-    return () => clearTimeout(id);
+    setToastClosing(false);
+    const closeAt = setTimeout(() => setToastClosing(true), 2200);
+    const dropAt = setTimeout(() => setToast(null), 2500);
+    return () => {
+      clearTimeout(closeAt);
+      clearTimeout(dropAt);
+    };
   }, [toast]);
 
   useEffect(() => {
@@ -118,7 +124,25 @@ export default function ListDetail({ listId, onBack, onEdit }: Props) {
 
       </div>
 
-      {toast && <div className="toast">{toast}</div>}
+      {toast && (
+        <div
+          className={`ios-notif ${toastClosing ? "closing" : ""}`}
+          role="status"
+          aria-live="polite"
+        >
+          <div className="ios-notif-icon" aria-hidden>
+            pp
+          </div>
+          <div className="ios-notif-body">
+            <div className="ios-notif-row">
+              <strong className="ios-notif-app">Ping Pong</strong>
+              <span className="ios-notif-time">now</span>
+            </div>
+            <div className="ios-notif-msg">{toast}</div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
+

--- a/src/styles.css
+++ b/src/styles.css
@@ -671,28 +671,90 @@ a {
   margin-top: 24px;
 }
 
-.toast {
+/* iOS-style notification banner */
+.ios-notif {
   position: absolute;
-  left: 50%;
-  bottom: 84px;
-  transform: translateX(-50%);
-  background: var(--purple);
-  color: #1a0820;
-  padding: 10px 14px;
-  border-radius: 999px;
+  top: 12px;
+  left: 12px;
+  right: 12px;
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 10px 12px;
+  border-radius: 18px;
+  background: rgba(40, 28, 28, 0.78);
+  -webkit-backdrop-filter: saturate(180%) blur(22px);
+  backdrop-filter: saturate(180%) blur(22px);
+  box-shadow:
+    0 12px 32px rgba(0, 0, 0, 0.45),
+    inset 0 0 0 0.5px rgba(255, 255, 255, 0.08);
+  pointer-events: none;
+  z-index: 20;
+  animation: ios-notif-in 420ms cubic-bezier(0.34, 1.6, 0.4, 1);
+}
+.ios-notif.closing {
+  animation: ios-notif-out 280ms ease forwards;
+}
+.ios-notif-icon {
+  width: 38px;
+  height: 38px;
+  border-radius: 9px;
+  background: var(--green);
+  display: grid;
+  place-items: center;
+  font-weight: 900;
+  font-size: 13px;
+  color: var(--purple);
+  letter-spacing: -0.05em;
+  flex-shrink: 0;
+  box-shadow: inset 0 0 0 0.5px rgba(255, 255, 255, 0.08);
+}
+.ios-notif-body {
+  flex: 1;
+  min-width: 0;
+}
+.ios-notif-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+.ios-notif-app {
   font-size: 13px;
   font-weight: 600;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
-  animation: pop 220ms ease;
-  pointer-events: none;
+  letter-spacing: -0.01em;
+  color: var(--text);
 }
-@keyframes pop {
-  from {
-    transform: translate(-50%, 6px);
+.ios-notif-time {
+  font-size: 12px;
+  color: var(--text-dim);
+  flex-shrink: 0;
+}
+.ios-notif-msg {
+  font-size: 14px;
+  line-height: 1.3;
+  margin-top: 2px;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+@keyframes ios-notif-in {
+  0% {
+    transform: translateY(-140%);
     opacity: 0;
   }
-  to {
-    transform: translate(-50%, 0);
+  60% {
+    transform: translateY(4px);
     opacity: 1;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+@keyframes ios-notif-out {
+  to {
+    transform: translateY(-140%);
+    opacity: 0;
   }
 }


### PR DESCRIPTION
Replaces the small pill toast that confirmed a smash with an iOS-style notification banner that drops in from the top of the phone:

- Blurred translucent dark background
- App badge ("pp") on the left
- Bold "Ping Pong" title with a "now" timestamp on the right
- Smash message in the body
- Spring entrance, slide-up dismissal, ~2.2s display

https://claude.ai/code/session_016MpnftzBfyNmfW864UVSBa

---
_Generated by [Claude Code](https://claude.ai/code/session_016MpnftzBfyNmfW864UVSBa)_